### PR TITLE
Improve ESLint config and fix linting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,23 @@ Detailed environment setup instructions are described at the beginning of the `D
 ```
 
 Go to http://localhost:8080/ and you should see the app running. When you change assets during development, it is recommended to perform a hard refresh [(⌘ + ⇧ + r)](https://support.google.com/chrome/answer/157179) instead of a regular browser reload.
+
+## Debugging with Chrome DevTools
+
+This project generates source maps (`sourcemap: true` in `rollup.config.ts`), so you can step through the original TypeScript source in Chrome DevTools.
+
+1. Open http://localhost:8080/ in Google Chrome
+2. Open DevTools with **F12** (or **⌘ + Option + I** on Mac)
+3. Go to the **Sources** tab
+4. In the left pane file tree, locate the original `.ts` files mapped via source maps
+5. Click a line number to set a **breakpoint**
+6. Reload the page (**⌘ + R** / **Ctrl + R**) — execution will pause at the breakpoint
+
+### Step execution shortcuts
+
+| Action | Shortcut |
+|---|---|
+| Resume | F8 |
+| Step over (next line) | F10 |
+| Step into (enter function) | F11 |
+| Step out (exit function) | Shift + F11 |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -91,7 +91,29 @@ export default tseslint.config(
   {
     languageOptions: {
       parserOptions: {
-        projectService: true,
+        //
+        // strictTypeChecked は全ファイルに @typescript-eslint/parser を適用し、
+        // projectService 経由で型情報を要求する。しかし tsconfig.json は
+        // デフォルトで .ts のみを対象とするため、.js ファイルは Project Service に
+        // 認識されず Parsing error になる。
+        //
+        // allowDefaultProject で .js ファイルを列挙し、defaultProject で
+        // allowJs: true を設定した ESLint 専用 tsconfig を指定することで、
+        // .js ファイルにも型情報を提供する。
+        //
+        // 注意: allowDefaultProject は ** を含む再帰 glob を禁止しているため、
+        // ディレクトリ階層ごとに個別のパターンを指定する必要がある。
+        // また、デフォルト上限は 8 ファイルである。
+        //
+        projectService: {
+          allowDefaultProject: [
+            'eslint.config.js',
+            'src/get-files/*.js',
+            'src/get-files/a/*.js',
+            'src/get-files/b/*.js',
+          ],
+          defaultProject: './tsconfig.eslint.json',
+        },
         tsconfigRootDir: import.meta.dirname,
       },
     },
@@ -196,6 +218,22 @@ export default tseslint.config(
           'response',
         ],
       }],
+    },
+  },
+
+  //
+  // Override for JS files
+  //
+  // JS ファイルは TypeScript のグローバル型定義 (lib.dom.d.ts 等) が適用されないため、
+  // console 等のグローバル変数が no-undef で未定義扱いになる。
+  // Node.js 環境のグローバル変数を明示的に設定する。
+  //
+  {
+    files: ['**/*.js'],
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+      },
     },
   },
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
-import tseslint from 'typescript-eslint';
-import importX from 'eslint-plugin-import-x';
+import { defineConfig, globalIgnores } from 'eslint/config';
+import { configs as tseslintConfigs } from 'typescript-eslint';
+import { flatConfigs as importXFlatConfigs } from 'eslint-plugin-import-x';
 import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
 
 //
@@ -61,13 +62,11 @@ const namingConventionRule = [
   },
 ];
 
-export default tseslint.config(
+const eslintConfig = defineConfig(
   //
   // Global ignores
   //
-  {
-    ignores: ['dist/', '.Trash-*/'],
-  },
+  globalIgnores(['dist/', '.Trash-*/']),
 
   //
   // ESLint recommended rules
@@ -78,12 +77,12 @@ export default tseslint.config(
   // typescript-eslint strict + type-checked rules
   // https://typescript-eslint.io/getting-started/typed-linting/
   //
-  ...tseslint.configs.strictTypeChecked,
+  ...tseslintConfigs.strictTypeChecked,
 
   //
   // eslint-plugin-import-x recommended config
   //
-  importX.flatConfigs.recommended,
+  importXFlatConfigs.recommended,
 
   //
   // Shared settings for all TypeScript files
@@ -254,3 +253,4 @@ export default tseslint.config(
     },
   },
 );
+export default eslintConfig;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -170,6 +170,9 @@ const eslintConfig = defineConfig(
       // @typescript-eslint custom rules
       //
       '@typescript-eslint/naming-convention': namingConventionRule,
+      '@typescript-eslint/restrict-template-expressions': ['error', {
+        allowNumber: true,
+      }],
 
       //
       // import-x rules

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import importX from 'eslint-plugin-import-x';
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript';
 
 //
 // Naming conventions
@@ -83,7 +84,6 @@ export default tseslint.config(
   // eslint-plugin-import-x recommended config
   //
   importX.flatConfigs.recommended,
-  importX.flatConfigs.typescript,
 
   //
   // Shared settings for all TypeScript files
@@ -95,7 +95,56 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    //
+    // import-x TypeScript settings
+    //
+    // importX.flatConfigs.typescript を使わず手動で設定している理由:
+    //
+    // flatConfigs.typescript は 'import-x/resolver': { typescript: true } を設定するが、
+    // これはレガシーリゾルバ API で eslint-import-resolver-typescript パッケージを探す仕組み。
+    // 内部で requireResolver("typescript") が呼ばれた際、eslint-import-resolver-typescript が
+    // 見つからないと TypeScript コンパイラ本体が代わりに読み込まれ、リゾルバインターフェースを
+    // 満たさないため "typescript with invalid interface loaded as resolver" エラーになる。
+    //
+    // これを避けるため、flatConfigs.typescript を削除し、以下のように手動で設定する:
+    // - settings: flatConfigs.typescript が提供していた extensions/parsers 等を手動記述
+    // - resolver-next: 新しいリゾルバ API (interfaceVersion 3) で eslint-import-resolver-typescript を使用
+    //
+    // 詳細: eslint-import-resolver-explanation.md
+    //
+    settings: {
+      // import-x がモジュール解決時に認識する拡張子
+      // （flatConfigs.typescript では .cts/.mts も含まれるが、このプロジェクトでは未使用のため省略）
+      'import-x/extensions': ['.ts', '.tsx', '.js', '.jsx'],
+      // @types/* パッケージの型定義も外部モジュールとして認識させる
+      'import-x/external-module-folders': ['node_modules', 'node_modules/@types'],
+      // .ts/.tsx ファイルを @typescript-eslint/parser でパースさせる
+      'import-x/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.tsx'],
+      },
+      //
+      // resolver-next: 新しいリゾルバ API (interfaceVersion 3)
+      //
+      // レガシーの 'import-x/resolver' ではなく 'import-x/resolver-next' を使用する。
+      // resolve.js の fullResolve() は resolver-next が設定されていればレガシーパスを
+      // 完全にバイパスし、{ typescript: true } による誤ったリゾルバ読み込みを回避できる。
+      //
+      // createTypeScriptImportResolver は eslint-import-resolver-typescript が提供する関数で、
+      // tsconfig.json の paths/baseUrl 解決、package.json exports 解釈、
+      // .ts → .js 拡張子マッピング等に対応する。
+      //   https://github.com/import-js/eslint-import-resolver-typescript
+      //
+      'import-x/resolver-next': [
+        createTypeScriptImportResolver({
+          // @types/* パッケージからの型解決を常に試みる
+          alwaysTryTypes: true,
+        }),
+      ],
+    },
     rules: {
+      // TypeScript の型情報を使った named export の検証は不要
+      // （flatConfigs.typescript が設定していたルール）
+      'import-x/named': 'off',
       //
       // @typescript-eslint custom rules
       //

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -181,7 +181,13 @@ export default tseslint.config(
       //   https://nodejs.org/api/esm.html#esm_mandatory_file_extensions
       //   https://github.com/import-js/eslint-plugin-import/blob/v2.17.2/docs/rules/extensions.md#examples
       //
-      'import-x/extensions': ['error', 'always', { ignorePackages: true }],
+      'import-x/extensions': ['error', 'always', {
+        ignorePackages: true,
+        pattern: {
+          ts: 'never',
+          tsx: 'never',
+        },
+      }],
 
       //
       // https://engineering.linecorp.com/ja/blog/you-dont-need-default-export

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@rollup/plugin-typescript": "^12.1.2",
         "@uraitakahito/rollup-plugin-copy": "^3.5.4",
         "eslint": "^9.39.3",
+        "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import-x": "^4.16.1",
         "npm-check-updates": "^17.1.13",
         "rollup": "^4.59.0",
@@ -1124,7 +1125,6 @@
       "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.56.1",
@@ -1850,6 +1850,41 @@
         }
       }
     },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-import-x": {
       "version": "4.16.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.16.1.tgz",
@@ -2363,6 +2398,16 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
     },
     "node_modules/is-core-module": {
       "version": "2.15.1",
@@ -3195,7 +3240,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "napi-postinstall": "^0.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@rollup/plugin-typescript": "^12.1.2",
     "@uraitakahito/rollup-plugin-copy": "^3.5.4",
     "eslint": "^9.39.3",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import-x": "^4.16.1",
     "npm-check-updates": "^17.1.13",
     "rollup": "^4.59.0",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -88,7 +88,7 @@ const config: RollupOptions[] = [
     //
     onwarn(warning, warn) {
       if (warning.code === 'UNRESOLVED_IMPORT') {
-        throw new Error(`Unresolved import: ${warning}`);
+        throw new Error(`Unresolved import: ${warning.message}`);
       }
       warn(warning);
     },

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import type { RollupOptions } from 'rollup';
 
 import typescript from '@rollup/plugin-typescript';

--- a/src/fizzbuzz.ts
+++ b/src/fizzbuzz.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /* eslint-disable no-console */
 function fizzbuzz(n: number): number | 'Fizz' | 'Buzz' | 'FizzBuzz' {
   if (n % 15 === 0) {

--- a/src/import-check/import-internal-esmodule.ts
+++ b/src/import-check/import-internal-esmodule.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-duplicates */
+/* eslint-disable import-x/no-duplicates */
 /* eslint-disable no-console */
 
 // MEMO:

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,8 @@
 // https://github.com/mdn/js-examples/tree/main/module-examples/basic-modules
-/* eslint-disable no-magic-numbers */
-import { create, createReportList } from './modules/canvas.js';
+import { create, createReportList } from './modules/canvas';
 import randomSquare, {
   draw, reportArea, reportPerimeter,
-} from './modules/square.js';
+} from './modules/square';
 
 const root = document.getElementById('root');
 

--- a/src/modules/square.ts
+++ b/src/modules/square.ts
@@ -1,6 +1,3 @@
-/* eslint-disable max-len */
-/* eslint-disable no-magic-numbers */
-/* eslint-disable no-param-reassign */
 const name = 'square';
 
 const draw = (ctx: CanvasRenderingContext2D, length: number, x: number, y: number, color: string) => {

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    // JS ファイルを TypeScript プロジェクトに含める
+    "allowJs": true,
+    // JS ファイルの型チェックを有効化し、@typescript-eslint ルールに型情報を提供する
+    "checkJs": true,
+    // ESLint 専用 tsconfig からファイルを出力しない
+    // (ビルドは tsconfig.json + Rollup が担当)
+    "noEmit": true,
+    // node_modules 内の .d.ts の型エラーを無視する
+    // (eslint-plugin-import-x が依存する type-fest の型定義が見つからないエラーを回避)
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

- Add Chrome DevTools debugging instructions to README
- Fix import-x resolver by migrating to resolver-next API (`createTypeScriptImportResolver`)
- Fix ESLint parsing errors for JS files by configuring `projectService.allowDefaultProject` with `tsconfig.eslint.json`
- Fix `import-x/extensions` errors and clean up unnecessary `eslint-disable` directives
- Migrate `eslint.config.js` from `tseslint.config()` to ESLint `defineConfig()`
- Fix `restrict-template-expressions` and `no-base-to-string` errors by allowing number in templates and using `warning.message`

## Test plan

- [ ] `npx eslint .` reports 0 errors (only `no-console` warnings expected)
- [ ] `npm run build` completes successfully for all 8 bundles
- [ ] Verify the app works at http://localhost:8080/ after rebuilding

🤖 Generated with [Claude Code](https://claude.com/claude-code)