### PR TITLE
develop

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,34 +1,64 @@
 {
   "recommendations": [
     //
-    // TypeScript
+    // Git & GitHub
     //
-    // https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors
-    "yoavbls.pretty-ts-errors",
+    // https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
+    "eamodio.gitlens",
+    // https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat
+    "GitHub.copilot-chat",
+    // https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions
+    "GitHub.vscode-github-actions",
+
+    //
+    // JSON
+    //
+    // https://marketplace.visualstudio.com/items?itemName=remcohaszing.schemastore
+    "remcohaszing.schemastore",
+
+    //
+    // Mermaid
+    //
+    // https://marketplace.visualstudio.com/items?itemName=bierner.markdown-mermaid
+    "bierner.markdown-mermaid",
+    // https://marketplace.visualstudio.com/items?itemName=bpruitt-goddard.mermaid-markdown-syntax-highlighting
+    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+
+    //
+    // YAML
+    //
+    // https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
+    "redhat.vscode-yaml",
+
     //
     // HTML
     //
     // https://marketplace.visualstudio.com/items?itemName=anteprimorac.html-end-tag-labels
     "anteprimorac.html-end-tag-labels",
-    // https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
-    "esbenp.prettier-vscode",
     // https://marketplace.visualstudio.com/items?itemName=formulahendry.auto-rename-tag
     "formulahendry.auto-rename-tag",
+
+    //
+    // Linter & Formatter
+    //
+    // https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
+    "dbaeumer.vscode-eslint",
+    // https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
+    "esbenp.prettier-vscode",
+
+    //
+    // TypeScript
+    //
+    // https://marketplace.visualstudio.com/items?itemName=yoavbls.pretty-ts-errors
+    "yoavbls.pretty-ts-errors",
+
     //
     // Others
     //
     // https://marketplace.visualstudio.com/items?itemName=dbankier.vscode-quick-select
     "dbankier.vscode-quick-select",
-    // https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
-    "eamodio.gitlens",
-    // https://marketplace.visualstudio.com/items?itemName=GitHub.copilot
-    "GitHub.copilot",
     // https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github
     "GitHub.vscode-pull-request-github",
-    // https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-github-actions
-    "GitHub.vscode-github-actions",
-    // https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml
-    "redhat.vscode-yaml",
     // https://marketplace.visualstudio.com/items?itemName=timonwong.shellcheck
     "timonwong.shellcheck",
     // https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -33,7 +33,5 @@
     "timonwong.shellcheck",
     // https://marketplace.visualstudio.com/items?itemName=usernamehw.errorlens
     "usernamehw.errorlens",
-    // https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode
-    "VisualStudioExptTeam.vscodeintellicode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
   // you **MUST RUN** the TypeScript: Select TypeScript Version command
   // and select the workspace version.
   // https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-newer-typescript-versions
-  "typescript.tsdk": "./node_modules/typescript/lib",
+  "js/ts.tsdk.path": "./node_modules/typescript/lib",
 
   // https://code.visualstudio.com/docs/typescript/typescript-editing
   "typescript.implementationsCodeLens.enabled": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,7 @@
 
   // https://code.visualstudio.com/docs/typescript/typescript-editing
   "js/ts.implementationsCodeLens.enabled": true,
-  "typescript.referencesCodeLens.enabled": true,
+  "js/ts.referencesCodeLens.enabled": true,
   "typescript.suggest.autoImports": true,
 
   //

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,7 @@
   // https://code.visualstudio.com/docs/typescript/typescript-editing
   "js/ts.implementationsCodeLens.enabled": true,
   "js/ts.referencesCodeLens.enabled": true,
-  "typescript.suggest.autoImports": true,
+  "js/ts.suggest.autoImports": true,
 
   //
   // ESLint

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,7 +27,7 @@
   "js/ts.tsdk.path": "./node_modules/typescript/lib",
 
   // https://code.visualstudio.com/docs/typescript/typescript-editing
-  "typescript.implementationsCodeLens.enabled": true,
+  "js/ts.implementationsCodeLens.enabled": true,
   "typescript.referencesCodeLens.enabled": true,
   "typescript.suggest.autoImports": true,
 


### PR DESCRIPTION
- **Add Chrome DevTools debugging instructions to README**
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Fix import-x resolver by migrating to resolver-next API**
  Replace flatConfigs.typescript with manual settings and resolver-next
  to fix "typescript with invalid interface loaded as resolver" errors.
  The legacy resolver config was loading the TypeScript compiler instead
  of eslint-import-resolver-typescript, causing all import resolution
  to fail.
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Fix ESLint parsing errors for JS files by configuring projectService defaultProject**
  JS files (eslint.config.js, src/get-files/*.js) were not recognized by
  TypeScript's Project Service because tsconfig.json only includes .ts files
  by default. Added tsconfig.eslint.json with allowJs/checkJs and configured
  projectService.allowDefaultProject to resolve the parsing errors.
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Fix import-x/extensions ESLint errors and clean up eslint-disable directives**
  - Allow extensionless imports for .ts/.tsx files in import-x/extensions rule,
    since @rollup/plugin-typescript is incompatible with allowImportingTsExtensions
  - Remove incorrect .js extensions from TS module imports in main.ts
  - Fix eslint-disable prefix from import/ to import-x/ in import-internal-esmodule.ts
  - Remove unused eslint-disable directives from rollup.config.ts, fizzbuzz.ts,
    main.ts, and square.ts
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Migrate eslint.config.js from tseslint.config() to ESLint defineConfig()**
  Replace deprecated tseslint.config() with ESLint core defineConfig(),
  switch to named imports for typescript-eslint and eslint-plugin-import-x,
  and use named export to resolve no-anonymous-default-export error.
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Fix restrict-template-expressions and no-base-to-string ESLint errors**
  Allow number in template literals via allowNumber option, and use
  warning.message instead of the RollupLog object in onwarn handler.
  
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Update LICENSE to reflect public domain dedication and remove Apache License**
  

- **Replace deprecated typescript.tsdk with js/ts.tsdk.path in VS Code settings**
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Replace deprecated typescript.implementationsCodeLens.enabled with js/ts prefix**
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Replace deprecated typescript.referencesCodeLens.enabled with js/ts prefix**
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Replace deprecated typescript.suggest.autoImports with js/ts prefix**
  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
  

- **Remove Visual Studio IntelliCode extension from recommendations**
  

- **Reorganize VS Code extension recommendations for better clarity**
  